### PR TITLE
Add instruction to put permalink: pretty in _config.yml

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,11 @@ Initial development by [Thomas Parslow](http://almostobsolete.net). Pull request
 
 [![Build Status](https://travis-ci.org/almost/hubbub.svg)](https://travis-ci.org/almost/hubbub) 
 
+**`_config.yml` Changes**
+----------------
+
+You need to have `permalink: pretty` in `_config.yml`.
+
 Quick Deployment
 ----------------
 


### PR DESCRIPTION
hubbub regex expects urls to be in `permalink: pretty` fashion. In absence of this setting the hubbub regexp fails.